### PR TITLE
fixed capitalization for footer image files

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -59,16 +59,16 @@ export default function Layout({ crumbLabel, children }) {
           height={35}
         />
         <StaticImage
-          src="../../images/logos/Bloomworks.png"
+          src="../../images/logos/bloomworks.png"
           alt="Bloomworks"
           height={35}
         />
         <StaticImage
-          src="../../images/logos/Organize.png"
+          src="../../images/logos/organize.png"
           alt="Organize"
           height={35}
         />
-        <StaticImage src="../../images/logos/FAS.png" alt="FAS" height={35} />
+        <StaticImage src="../../images/logos/fas.png" alt="FAS" height={35} />
       </Row>
     </Container>
   );


### PR DESCRIPTION
[Footer Images Ticket](https://trello.com/c/ghRmixY1/61-bug-footer-images-missing-small)

fixed capitalization for footer image files