### PR TITLE
16: Replaces investigation bool with link

### DIFF
--- a/src/hooks/useDataMaps.js
+++ b/src/hooks/useDataMaps.js
@@ -10,6 +10,7 @@ export default function useDataMaps() {
               compensation
               donors
               investigation
+              investigation_url
               name
               opo
               nhw_donors

--- a/src/pages/opo/[opo].js
+++ b/src/pages/opo/[opo].js
@@ -17,6 +17,7 @@ import {
 
 import useDataMaps from "../../hooks/useDataMaps";
 import stateContent from "../state/[state].content.yml";
+import { BoxArrowUpRight } from "react-bootstrap-icons";
 import opoContent from "./[opo].content.yml";
 
 import * as styles from "./opo.module.css";
@@ -132,13 +133,10 @@ export default function Opo({ opo }) {
                 <p className="red">{formatNumber(opoData.shadows)}</p>
               </Col>
               <Col>
-                <p>
-                  {opoData.investigation
-                    ? "Yes"
-                    : opoData.investigation === null
-                    ? "No Data"
-                    : "No"}
-                </p>
+                  {!!opoData.investigation
+                    ? <a href={opoData.investigation_url} target="_blank"> Yes <BoxArrowUpRight /> </a>
+                    : <p>No</p>
+                  }
               </Col>
             </Row>
             <Row className={styles.statsComp}>

--- a/src/pages/opo/opo.module.css
+++ b/src/pages/opo/opo.module.css
@@ -112,9 +112,13 @@
   color: #d43c37;
 }
 
-.statsPopout p {
+.statsPopout p, .statsPopout a {
   font-size: 2rem;
   font-weight: 700;
+}
+
+.statsPopout svg {
+  height: 1rem;
 }
 
 .headlines {


### PR DESCRIPTION
remaining question:
- Previously there was logic for 3 cases: "Yes", "No", "No data". However, because the column was a boolean, the "No data" condition (investigation === null) was never met. Do we have the necessary data available to distinguish between "No" and "No data" and are we interested in distinguishing in the app?